### PR TITLE
D-N 라벨 워크플로에 필요한 권한 추가

### DIFF
--- a/.github/workflows/d-day-labeler.yml
+++ b/.github/workflows/d-day-labeler.yml
@@ -6,6 +6,7 @@ name: Update D-n Labels
 on:
   schedule:
     - cron: '0 15 * * *' # 매일 밤 12시에 실행 (KST 기준)
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요. 예: Resolves #이슈번호 -->
- Resolves #6 

<br>

## 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능) -->
D-Day 라벨 자동 업데이트 및 PR 라벨 자동화 워크플로(`simple-labeler`, `d-day-labeler`)가  라벨 추가/삭제 작업을 수행하기 위해 필요한 GitHub Actions 권한을 명시적으로 부여했습니다.

기존에는 기본 GITHUB_TOKEN 권한이 read-only로 동작해 아래 오류가 발생하며 라벨 업데이트가 실패하는 문제가 있었습니다.
```Error: Resource not accessible by integration```
이번 PR에서는 해당 문제를 해결하기 위해  워크플로 파일 상단에 다음 권한 설정을 추가했습니다.
```yaml
permissions:
  contents: read
  pull-requests: write
  issues: write
```
<br>

## 참고 자료 (선택)
<!-- 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요 -->
<br>
