### PR TITLE
토론 상세 화면의 정보 섹션 `Row -> FlowRow`로 변경

### DIFF
--- a/Dialog/feature/discussiondetail/impl/src/commonMain/kotlin/com/on/dialog/discussiondetail/impl/DiscussionDetailScreen.kt
+++ b/Dialog/feature/discussiondetail/impl/src/commonMain/kotlin/com/on/dialog/discussiondetail/impl/DiscussionDetailScreen.kt
@@ -249,7 +249,7 @@ private fun DiscussionDetailScreenOfflinePreview() {
                             ParticipantUiModel(id = 1L, name = "제리"),
                             ParticipantUiModel(id = 2L, name = "크림"),
                         ),
-                        dateTimePeriod = "2023년 3월 1일 13시 ~ 15시",
+                        dateTimePeriod = "2023년 3월 1일 13시 15분 ~ 15시 15분",
                     ),
                     isMyDiscussion = true,
                 ),

--- a/Dialog/feature/discussiondetail/impl/src/commonMain/kotlin/com/on/dialog/discussiondetail/impl/component/DiscussionDetailHeader.kt
+++ b/Dialog/feature/discussiondetail/impl/src/commonMain/kotlin/com/on/dialog/discussiondetail/impl/component/DiscussionDetailHeader.kt
@@ -218,9 +218,10 @@ private fun InfoSection(
 
         Spacer(modifier = Modifier.height(DialogTheme.spacing.small))
 
-        Row(
+        FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(DialogTheme.spacing.small),
+            verticalArrangement = Arrangement.spacedBy(DialogTheme.spacing.small),
         ) {
             formattedDateTime?.let { text ->
                 MetaChip(
@@ -323,7 +324,7 @@ private fun OfflineDiscussionDetailHeaderPreview() {
                         ParticipantUiModel(id = 1L, name = "제리"),
                         ParticipantUiModel(id = 2L, name = "크림"),
                     ),
-                    dateTimePeriod = "2023년 3월 1일 13시 ~ 15시",
+                    dateTimePeriod = "2023년 3월 1일 13시 15분 ~ 15시 15분",
                 ),
                 isBookmarked = false,
                 isLiked = true,


### PR DESCRIPTION
## 연관된 이슈
<!-- 관련된 이슈 번호를 적어주세요. 예: Resolves #이슈번호 -->
- Resolves #77 

<br>

## 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능) -->
기존의 토론 상세 화면의 정보 섹션은 `Row`로 되어있어 텍스트가 길어지는 경우 UI가 정상적으로 표시되지 않는 문제가 있었습니다.
때문에 텍스트가 길어지는 경우 칩이 세로로 나열될 수 있도록 `FlowRow`로 변경하였습니다.
<br>

## 참고 자료 (선택)
<!-- 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요 -->
| 변경 전 | 변경 후 |
|--------|--------|
| <img width="293" height="219" alt="image" src="https://github.com/user-attachments/assets/b599d5aa-2912-4148-9636-e19c06eab8e7" /> | <img width="295" height="235" alt="image" src="https://github.com/user-attachments/assets/715ee710-1c50-4f8b-9fdc-7484500d4bf8" /> |

<br>
